### PR TITLE
fix: remove unused constant

### DIFF
--- a/erc20/contracts/ERC20.huff
+++ b/erc20/contracts/ERC20.huff
@@ -25,7 +25,6 @@
 
 /* Storage Slots */
 #define constant BALANCE_LOCATION = FREE_STORAGE_POINTER()
-#define constant ALLOWANCE_LOCATION = FREE_STORAGE_POINTER()
 #define constant TOTAL_SUPPLY_LOCATION = FREE_STORAGE_POINTER()
 
 /* Constructor */


### PR DESCRIPTION
This pr removes the unused ALLOWANCE_LOCATION constant in ERC20.

https://discord.com/channels/980519274600882306/980576949808300082/981226803370815518
