### PR TITLE
Fix SEND_ETH Macro

### DIFF
--- a/src/ERC20/utils/Address.huff
+++ b/src/ERC20/utils/Address.huff
@@ -13,6 +13,11 @@
     0x00    // [0, 0, 0, 0, amount, address]
     dup5    // [amount, 0, 0, 0, 0, amount, address]
     dup7    // [address, amount, 0, 0, 0, 0, amount]
+    gas     // [gas, address, amount, 0, 0, 0, 0, amount]
+    call    // [success, amount]
+
+    swap1   // [amount ,success]
+    pop     // [success]
 }
 
 #define macro MASK_ADDRESS() = takes(1) returns (1) {

--- a/src/ERC20/utils/Address.huff
+++ b/src/ERC20/utils/Address.huff
@@ -12,11 +12,13 @@
     0x00    // [0, 0, 0, amount, address]
     0x00    // [0, 0, 0, 0, amount, address]
     dup5    // [amount, 0, 0, 0, 0, amount, address]
-    dup7    // [address, amount, 0, 0, 0, 0, amount]
-    gas     // [gas, address, amount, 0, 0, 0, 0, amount]
-    call    // [success, amount]
+    dup7    // [address, amount, 0, 0, 0, 0, amount, address]
+    gas     // [gas, address, amount, 0, 0, 0, 0, amount, address]
+    call    // [success, amount, address]
 
-    swap1   // [amount ,success]
+    swap1   // [amount, success, address]
+    pop     // [success, address]
+    swap1   // [address, success]
     pop     // [success]
 }
 

--- a/src/ERC721/utils/Address.huff
+++ b/src/ERC721/utils/Address.huff
@@ -13,6 +13,11 @@
     0x00    // [0, 0, 0, 0, amount, address]
     dup5    // [amount, 0, 0, 0, 0, amount, address]
     dup7    // [address, amount, 0, 0, 0, 0, amount]
+    gas     // [gas, address, amount, 0, 0, 0, 0, amount]
+    call    // [success, amount]
+
+    swap1   // [amount ,success]
+    pop     // [success]
 }
 
 #define macro MASK_ADDRESS() = takes(1) returns (1) {

--- a/src/ERC721/utils/Address.huff
+++ b/src/ERC721/utils/Address.huff
@@ -12,11 +12,13 @@
     0x00    // [0, 0, 0, amount, address]
     0x00    // [0, 0, 0, 0, amount, address]
     dup5    // [amount, 0, 0, 0, 0, amount, address]
-    dup7    // [address, amount, 0, 0, 0, 0, amount]
-    gas     // [gas, address, amount, 0, 0, 0, 0, amount]
-    call    // [success, amount]
+    dup7    // [address, amount, 0, 0, 0, 0, amount, address]
+    gas     // [gas, address, amount, 0, 0, 0, 0, amount, address]
+    call    // [success, amount, address]
 
-    swap1   // [amount ,success]
+    swap1   // [amount, success, address]
+    pop     // [success, address]
+    swap1   // [address, success]
     pop     // [success]
 }
 


### PR DESCRIPTION
In Address.huff SEND_ETH macro, the contract didn't have the call opcode.

I'm not sure if it was on purpose if so, then just ignore this PR.
